### PR TITLE
Support ignoring different policies for Trivy

### DIFF
--- a/templates/trivy/trivy-advanced-policies-cm.yaml
+++ b/templates/trivy/trivy-advanced-policies-cm.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.trivy.enabled }}
+{{- if eq .Values.trivy.ignorePolicy "advanced" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-advanced-policies
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  advanced.rego: |
+    package trivy
+
+    import data.lib.trivy
+    
+    default ignore = false
+    
+    nvd_v3_vector = v {
+      v := input.CVSS.nvd.v3
+    }
+    
+    # Ignore a vulnerability which requires high privilege
+    ignore {
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+      cvss_vector.PrivilegesRequired == "High"
+    }
+    
+    # Ignore a vulnerability which requires user interaction
+    ignore {
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+      cvss_vector.UserInteraction == "Required"
+    }
+    
+    ignore {
+      input.PkgName == "openssl"
+    
+      # Split CVSSv3 vector
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+    
+      # Evaluate Attack Vector
+      ignore_attack_vectors := {"Physical", "Local"}
+      cvss_vector.AttackVector == ignore_attack_vectors[_]
+    }
+    
+    ignore {
+      input.PkgName == "openssl"
+    
+      # Evaluate severity
+      input.Severity == {"LOW", "MEDIUM", "HIGH"}[_]
+    
+      # Evaluate CWE-ID
+      deny_cwe_ids := {
+        "CWE-119", # Improper Restriction of Operations within the Bounds of a Memory Buffer
+        "CWE-200", # Exposure of Sensitive Information to an Unauthorized Actor
+      }
+    
+      count({x | x := input.CweIDs[_]; x == deny_cwe_ids[_]}) == 0
+    }
+    
+    ignore {
+      input.PkgName == "bash"
+    
+      # Split CVSSv3 vector
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+    
+      # Evaluate Attack Vector
+      ignore_attack_vectors := {"Physical", "Local", "Adjacent"}
+      cvss_vector.AttackVector == ignore_attack_vectors[_]
+    
+      # Evaluate severity
+      input.Severity == {"LOW", "MEDIUM", "HIGH"}[_]
+    }
+    
+    ignore {
+      input.PkgName == "django"
+    
+      # Split CVSSv3 vector
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+    
+      # Evaluate Attack Vector
+      ignore_attack_vectors := {"Physical", "Local"}
+      cvss_vector.AttackVector == ignore_attack_vectors[_]
+    
+      # Evaluate severity
+      input.Severity == {"LOW", "MEDIUM"}[_]
+    
+      # Evaluate CWE-ID
+      deny_cwe_ids := {
+        "CWE-89", # SQL Injection
+        "CWE-78", # OS Command Injection
+      }
+    
+      count({x | x := input.CweIDs[_]; x == deny_cwe_ids[_]}) == 0
+    }
+    
+    ignore {
+      input.PkgName == "jquery"
+    
+      # Split CVSSv3 vector
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+    
+      # Evaluate CWE-ID
+      deny_cwe_ids := {"CWE-79"} # XSS
+      count({x | x := input.CweIDs[_]; x == deny_cwe_ids[_]}) == 0
+    }
+{{- end }}
+{{- end }}

--- a/templates/trivy/trivy-basic-policies-cm.yaml
+++ b/templates/trivy/trivy-basic-policies-cm.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.trivy.enabled }}
+{{- if eq .Values.trivy.ignorePolicy "basic" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trivy-basic-policies
+  namespace: {{ .Release.Namespace | quote }}
+data:
+  basic.rego: |
+    package trivy
+
+    import data.lib.trivy
+
+    default ignore = false
+
+    ignore_pkgs := {"bash", "bind-license", "rpm", "vim", "vim-minimal"}
+
+    ignore_severities := {"LOW", "MEDIUM"}
+
+    nvd_v3_vector = v {
+      v := input.CVSS.nvd.v3
+    }
+
+    ignore {
+      input.PkgName == ignore_pkgs[_]
+    }
+
+    ignore {
+      input.Severity == ignore_severities[_]
+    }
+
+    # Ignore a vulnerability which is not remotely exploitable
+    ignore {
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+      cvss_vector.AttackVector != "Network"
+    }
+
+    # Ignore a vulnerability which requires high privilege
+    ignore {
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+      cvss_vector.PrivilegesRequired == "High"
+    }
+
+    # Ignore a vulnerability which requires user interaction
+    ignore {
+      cvss_vector := trivy.parse_cvss_vector_v3(nvd_v3_vector)
+      cvss_vector.UserInteraction == "Required"
+    }
+
+    # Ignore CSRF
+    ignore {
+      # https://cwe.mitre.org/data/definitions/352.html
+      input.CweIDs[_] == "CWE-352"
+    }
+{{- end }}
+{{- end }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -98,6 +98,10 @@ spec:
               value: {{ .Values.trivy.severity | quote }}
             - name: "SCANNER_TRIVY_IGNORE_UNFIXED"
               value: {{ .Values.trivy.ignoreUnfixed | default false | quote }}
+            {{- if ne .Values.trivy.ignorePolicy "none" }}
+            - name: "SCANNER_TRIVY_IGNORE_POLICY"
+              value: "/home/scanner/policies/{{ .Values.trivy.ignorePolicy }}.rego"
+            {{- end }}
             - name: "SCANNER_TRIVY_SKIP_UPDATE"
               value: {{ .Values.trivy.skipUpdate | default false | quote }}
             - name: "SCANNER_TRIVY_SKIP_JAVA_DB_UPDATE"
@@ -148,6 +152,10 @@ spec:
           - name: trivy-internal-certs
             mountPath: /etc/harbor/ssl/trivy
           {{- end }}
+          {{- if ne .Values.trivy.ignorePolicy "none" }}
+          - name: policies
+            mountPath: /home/scanner/policies
+          {{- end }}
           {{- if .Values.caBundleSecretName }}
 {{ include "harbor.caBundleVolumeMount" . | indent 10 }}
           {{- end }}
@@ -189,6 +197,11 @@ spec:
         persistentVolumeClaim:
           claimName: {{ $trivy.existingClaim }}
       {{- end }}
+      {{- end }}
+      {{- if ne .Values.trivy.ignorePolicy "none" }}
+      - name: policies
+        configMap:
+          name: trivy-{{ .Values.trivy.ignorePolicy }}-policies
       {{- end }}
     {{- with .Values.trivy.nodeSelector }}
       nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -839,6 +839,8 @@ trivy:
   severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   # ignoreUnfixed the flag to display only fixed vulnerabilities
   ignoreUnfixed: false
+  # Specify policies to ignore when displaying vulnerabilities. Options are "none", "basic" and "advanced".
+  ignorePolicy: "none"
   # insecure the flag to skip verifying registry certificate
   insecure: false
   # gitHubToken the GitHub access token to download Trivy DB


### PR DESCRIPTION
Set `trivy.ignorePolicy` to `none`, `basic` or `advanced` to have Trivy ignore certain policies when reporting vulnerabilities. `basic` and `advanced` levels are from [Trivy's example policies](https://github.com/aquasecurity/trivy/tree/v0.22.0/contrib/example_policy)